### PR TITLE
fix parsing the 'BINARY' keyword in VTK Legacy files

### DIFF
--- a/src/input/parsers/vtklegacy/parser/geometry.cpp
+++ b/src/input/parsers/vtklegacy/parser/geometry.cpp
@@ -86,7 +86,7 @@ VTKLegacyGeometry::Header::Header(InputFilePack &pack, const char *c)
 	if (StringCompare::caseInsensitiveEq(std::string(c, c + 5), "ASCII")) {
 		format = Format::ASCII;
 	}
-	if (StringCompare::caseInsensitiveEq(std::string(c, c + 5), "BINARY")) {
+	if (StringCompare::caseInsensitiveEq(std::string(c, c + 6), "BINARY")) {
 		format = Format::BINARY;
 	}
 	while (*c++ != '\n'); // format


### PR DESCRIPTION
The string length of "BINARY" is 6, not 5 as used in the original code.

But loading the BINARY files still does not work, there is at least this error:

    VTK Legacy parser: not implemented scanning of binary format.

It would be fair to point out the limitations of the parsers in the README.