### PR TITLE
fix build of vtklegacy parser

### DIFF
--- a/src/input/parsers/vtklegacy/parser/geometry.h
+++ b/src/input/parsers/vtklegacy/parser/geometry.h
@@ -12,6 +12,7 @@ namespace mesio {
 struct MeshBuilder;
 
 class VTKLegacyGeometry {
+public:
 	enum class Format {
 		BINARY,
 		ASCII,
@@ -81,7 +82,6 @@ class VTKLegacyGeometry {
 		Data(InputFilePack &pack, DataSource source, const char *c);
 	};
 
-public:
 	VTKLegacyGeometry(InputFilePack &pack);
 
 	void scan();


### PR DESCRIPTION
The `read` function implemented in https://github.com/It4innovations/mesio/commit/ff9349c842211205145410c2a0b46f5da340e54b uses the `VTKLegacyGeometry::Keyword` struct outside the class, so it must be defined in the public region. The error was:

```
../src/input/parsers/vtklegacy/parser/geometry.cpp: In instantiation of ‘void read(const mesio::InputFilePack&, mesio::VTKLegacyGeometry::Keyword&, std::vector<Tdistribution>&, size_t) [with Input = float; Output = double; size_t = long unsigned int]’:
../src/input/parsers/vtklegacy/parser/geometry.cpp:304:24:   required from here
../src/input/parsers/vtklegacy/parser/geometry.cpp:257:65: error: ‘struct mesio::VTKLegacyGeometry::Keyword’ is private within this context
  257 | void static read(const InputFilePack &_pack, VTKLegacyGeometry::Keyword &keyword, std::vector<Output> &output, size_t align)
      |                                                                 ^~~~~~~
In file included from ../src/input/parsers/vtklegacy/parser/geometry.cpp:2:
../src/input/parsers/vtklegacy/parser/geometry.h:38:16: note: declared private here
   38 |         struct Keyword {
      |                ^~~~~~~
```